### PR TITLE
bootanimation: Fix error when TARGET_SCREEN_ASPECT_RATIO is disabled

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -4,7 +4,7 @@ ifneq ($(TARGET_SCREEN_WIDTH) $(TARGET_SCREEN_HEIGHT),$(space))
 #check device aspect ratio (tablet or phone) to import full screen bootanimation where appropriate
 ifeq ($(TARGET_SCREEN_ASPECT_RATIO),16by9)
 # Set bootanimation size to width to differentiate between tablet and phone devices for aspect ratio
-TARGET_BOOTANIMATION_SIZE := $(TARGET_SCREEN_WIDTH); \
+TARGET_BOOTANIMATION_SIZE := $(TARGET_SCREEN_WIDTH)
 else
 # determine the smaller dimension
 TARGET_BOOTANIMATION_SIZE := $(shell \


### PR DESCRIPTION
- When TARGET_SCREEN_ASPECT_RATIO is disabled we get below error:
  /bin/bash: line 0: [: 1600: unary operator expected
  /bin/bash: line 0: [: 1536: unary operator expected
  /bin/bash: line 0: [: 1440: unary operator expected
  /bin/bash: line 0: [: 1200: unary operator expected
  /bin/bash: line 0: [: 1080: unary operator expected
  /bin/bash: line 0: [: 800: unary operator expected
  /bin/bash: line 0: [: 768: unary operator expected
  /bin/bash: line 0: [: 720: unary operator expected
  /bin/bash: line 0: [: 600: unary operator expected
  /bin/bash: line 0: [: 540: unary operator expected
  /bin/bash: line 0: [: 480: unary operator expected
  /bin/bash: line 0: [: 360: unary operator expected
  /bin/bash: line 0: [: 320: unary operator expected
  /bin/bash: line 0: [: 240: unary operator expected
  /bin/bash: line 0: [: 16by9: unary operator expected
  /bin/bash: line 0: [: halfres: unary operator expected
- This patch fixes this error.

Change-Id: I9d9e60df237eb07d8d3d8339e0eef84c508a08fd
Signed-off-by: Pranav Vashi neobuddy89@gmail.com
