### PR TITLE
Unary : I hate you, go away.

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -1,38 +1,32 @@
 PRODUCT_BRAND ?= cyanogenmod
 
-ifneq ($(TARGET_SCREEN_WIDTH) $(TARGET_SCREEN_HEIGHT),$(space))
 #check device aspect ratio (tablet or phone) to import full screen bootanimation where appropriate
+ifdef SCREEN_RATIO_PROPORTIONATE
 ifeq ($(SCREEN_RATIO_PROPORTIONATE),true)
 # Set bootanimation size to width to differentiate between tablet and phone devices for aspect ratio
 TARGET_BOOTANIMATION_SIZE := $(TARGET_SCREEN_WIDTH)
-TARGET_BOOTANIMATION_NAME := $(TARGET_BOOTANIMATION_SIZE)
+endif
 else
-# get a sorted list of the sizes
-bootanimation_sizes := $(subst .zip,, $(shell ls vendor/cm/prebuilt/common/bootanimation))
-bootanimation_sizes := $(shell echo -e $(subst $(space),'\n',$(bootanimation_sizes)) | sort -rn)
-
-# find the appropriate size and set
-define check_and_set_bootanimation
-$(eval TARGET_BOOTANIMATION_NAME := $(shell \
-  if [ -z "$(TARGET_BOOTANIMATION_NAME)" ]; then
-    if [ $(1) -le $(TARGET_BOOTANIMATION_SIZE) ]; then \
-      echo $(1); \
-      exit 0; \
-    fi;
-  fi;
-  echo $(TARGET_BOOTANIMATION_NAME); ))
-endef
-$(foreach size,$(bootanimation_sizes), $(call check_and_set_bootanimation,$(size)))
+# determine the smaller dimension
+TARGET_BOOTANIMATION_SIZE := $(shell \
+	if [ $(TARGET_SCREEN_WIDTH) -lt $(TARGET_SCREEN_HEIGHT) ]; then \
+    echo $(TARGET_SCREEN_WIDTH); \
+  else \
+    echo $(TARGET_SCREEN_HEIGHT); \
+  fi )
 endif
 
-ifeq ($(TARGET_BOOTANIMATION_HALF_RES),true)
-PRODUCT_BOOTANIMATION := vendor/cm/prebuilt/common/bootanimation/halfres/$(TARGET_BOOTANIMATION_NAME).zip
-endif
+TARGET_BOOTANIMATION_NAME := $(TARGET_BOOTANIMATION_SIZE)
+
+ifdef SCREEN_RATIO_PROPORTIONATE
 ifeq ($(SCREEN_RATIO_PROPORTIONATE),true)
 PRODUCT_BOOTANIMATION := vendor/cm/prebuilt/common/bootanimation/$(TARGET_SCREEN_ASPECT_RATIO)/$(TARGET_BOOTANIMATION_NAME).zip
+endif
 else
 PRODUCT_BOOTANIMATION := vendor/cm/prebuilt/common/bootanimation/$(TARGET_BOOTANIMATION_NAME).zip
 endif
+ifeq ($(TARGET_BOOTANIMATION_HALF_RES),true)
+PRODUCT_BOOTANIMATION := vendor/cm/prebuilt/common/bootanimation/halfres/$(TARGET_BOOTANIMATION_NAME).zip
 endif
 
 ifdef CM_NIGHTLY


### PR DESCRIPTION
Remove issue surrounding unary when code not defined
Fixes issue when using completely stock device trees
Further cleaned up code and rewrote how the correct bootanimation
size is located (we dont need to sort zip sizes, just need to find
correct size based on shortest width or height of device)
