### PR TITLE
Viper : fix up viper removal

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -118,7 +118,7 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     frameworks/base/data/keyboards/Vendor_045e_Product_028e.kl:system/usr/keylayout/Vendor_045e_Product_0719.kl
 
-ifneq ($(TARGET_ARCH),arm64)
+ifeq ($(TARGET_ARCH),arm)
 # Viper4Android
 PRODUCT_COPY_FILES += \
    vendor/cm/prebuilt/common/bin/audio_policy.sh:system/audio_policy.sh \


### PR DESCRIPTION
for some reason the ifneq would never remove viper it would still remain in builds.... viper has been spotty with x64 so removal is best option for now.
